### PR TITLE
Retrieve Prometheus annotation from Method

### DIFF
--- a/libraries/prometheus-jersey-filter/src/main/java/cd/connect/jersey/prometheus/PrometheusDynamicFeature.java
+++ b/libraries/prometheus-jersey-filter/src/main/java/cd/connect/jersey/prometheus/PrometheusDynamicFeature.java
@@ -32,7 +32,7 @@ public class PrometheusDynamicFeature implements DynamicFeature {
 
   @Override
   public void configure(ResourceInfo resourceInfo, FeatureContext context) {
-    Prometheus annotation = resourceInfo.getResourceClass().getAnnotation(Prometheus.class);
+    Prometheus annotation = resourceInfo.getResourceMethod().getAnnotation(Prometheus.class);
     if (annotation != null || profileAll) {
       context.register(new PrometheusFilter(resourceInfo, prefix, annotation));
     }


### PR DESCRIPTION
The Prometheus annotation can only be applied to methods. However, the
Prometheus Dynamic Feature attempts to retrieve this annotation from the
Resource Class (on configuration). This means that the annotation will
never be successfully retrieved since it can never be applied on the
class level.

This PR changes the Prometheus Dynamic Feature to start retrieving
the annotation from the Resource Method instead of the Class.