### PR TITLE
import all validation constraints instead of only @NotNull

### DIFF
--- a/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/ClientService.mustache
+++ b/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/ClientService.mustache
@@ -28,7 +28,7 @@ import javax.ws.rs.*;
 
 {{#useBeanValidation}}
   import javax.validation.Valid;
-  import javax.validation.constraints.NotNull;
+  import javax.validation.constraints.*;
 {{/useBeanValidation}}
 
 {{>generatedAnnotation}}

--- a/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/SecurityService.mustache
+++ b/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/SecurityService.mustache
@@ -28,7 +28,7 @@ import javax.ws.rs.*;
 
 {{#useBeanValidation}}
   import javax.validation.Valid;
-  import javax.validation.constraints.NotNull;
+  import javax.validation.constraints.*;
 {{/useBeanValidation}}
 
 {{>generatedAnnotation}}

--- a/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/Service.mustache
+++ b/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/Service.mustache
@@ -28,7 +28,7 @@ import java.util.Map;
 
 {{#useBeanValidation}}
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.*;
 {{/useBeanValidation}}
 
 {{>generatedAnnotation}}


### PR DESCRIPTION
Currently only @<!-- -->NotNull constraint is imported in the client, service and secure service.

This will lead to compile error if the api spec uses patterns or size constraints, since @<!-- -->Pattern and @<!-- -->Size annotations are never imported.

This PR fixes this issue by importing all constraints.