### PR TITLE
create a new map if the property is a map

### DIFF
--- a/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/pojo.mustache
+++ b/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/pojo.mustache
@@ -244,9 +244,14 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
        {{^isContainer}}
     copy.{{setter}}(this.{{getter}}());
        {{/isContainer}}
-       {{#isContainer}}
+       {{#isMapContainer}}
+        {{#isPrimitiveType}}
     copy.{{setter}}(this.{{getter}}() == null ? null : this.{{getter}}().entrySet().stream().collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-       {{/isContainer}}
+        {{/isPrimitiveType}}
+        {{^isPrimitiveType}}
+    copy.{{setter}}(this.{{getter}}() == null ? null : this.{{getter}}().entrySet().stream().collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, t -> t.getValue().copy())));
+        {{/isPrimitiveType}}
+       {{/isMapContainer}}
      {{/isListContainer}}
    {{/vars}}
 

--- a/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/pojo.mustache
+++ b/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/pojo.mustache
@@ -240,19 +240,22 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     copy.{{setter}}(this.{{getter}}() == null ? null : this.{{getter}}().stream().map(t -> t.copy()).collect(java.util.stream.Collectors.toList()));
        {{/complexType}}
      {{/isListContainer}}
-     {{^isListContainer}}
-       {{^isContainer}}
-    copy.{{setter}}(this.{{getter}}());
-       {{/isContainer}}
-       {{#isMapContainer}}
-        {{#isPrimitiveType}}
+     {{#isMapContainer}}
+      {{#isPrimitiveType}}
     copy.{{setter}}(this.{{getter}}() == null ? null : this.{{getter}}().entrySet().stream().collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-        {{/isPrimitiveType}}
-        {{^isPrimitiveType}}
+      {{/isPrimitiveType}}
+      {{^isPrimitiveType}}
     copy.{{setter}}(this.{{getter}}() == null ? null : this.{{getter}}().entrySet().stream().collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, t -> t.getValue().copy())));
-        {{/isPrimitiveType}}
-       {{/isMapContainer}}
-     {{/isListContainer}}
+      {{/isPrimitiveType}}
+     {{/isMapContainer}}
+     {{^isContainer}}
+      {{#isFreeFormObject}}
+    copy.{{setter}}(this.{{getter}}().copy());
+      {{/isFreeFormObject}}
+      {{^isFreeFormObject}}
+    copy.{{setter}}(this.{{getter}}());
+      {{/isFreeFormObject}}
+     {{/isContainer}}
    {{/vars}}
 
     return copy;

--- a/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/pojo.mustache
+++ b/maven-plugins/openapi-jersey2-plugin/src/main/resources/jersey2-v3template/pojo.mustache
@@ -245,7 +245,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     copy.{{setter}}(this.{{getter}}());
        {{/isContainer}}
        {{#isContainer}}
-    copy.{{setter}}(this.{{getter}}() == null ? null : this.{{getter}}().copy());
+    copy.{{setter}}(this.{{getter}}() == null ? null : this.{{getter}}().entrySet().stream().collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
        {{/isContainer}}
      {{/isListContainer}}
    {{/vars}}


### PR DESCRIPTION
The copy method in models does not correctly handle properties that are Maps.

When generating the copy method, the generated code tries to call the copy() method of java.util.Map class, which does not exist, causing compilation errors.

![image](https://user-images.githubusercontent.com/8444708/67343776-b9a2df00-f592-11e9-9a82-cac171f01c46.png)


This can be replicated by running the generation on the[demo-api.zip](https://github.com/ClearPointNZ/connect-java/files/3759113/demo-api.zip) attached. 

This commit allows the map to be copied.