### PR TITLE
merge-yaml-plugin: update to snakeyaml 1.26

### DIFF
--- a/maven-plugins/merge-yaml-plugin/pom.xml
+++ b/maven-plugins/merge-yaml-plugin/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.15</version>
+			<version>1.26</version>
 		</dependency>
 
 		<!-- mustache templates -->

--- a/tiles/tile-java/tile.xml
+++ b/tiles/tile-java/tile.xml
@@ -30,6 +30,7 @@
         </executions>
         <configuration>
           <failOnError>true</failOnError>
+          <source>1.8</source>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
We are using this plugin in a project based on https://github.com/quarkusio/quarkus.
Quarkus (as of 1.4.2.Final) is using the latest `snakeyaml` version 1.26 so we decided to bring this plugin in line with that.

The JavaDoc-commit is fixing this error when building the plugin with JDK11:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar (cd.connect.tiles:tile-java:1.2::attach-javadocs) on project merge-yaml-plugin: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
```