### PR TITLE
Updates for OpenAPI Libraries

### DIFF
--- a/libraries/openapi-jersey3-support/src/main/java/cd/connect/openapi/support/OpenApiEnumProvider.java
+++ b/libraries/openapi-jersey3-support/src/main/java/cd/connect/openapi/support/OpenApiEnumProvider.java
@@ -1,0 +1,55 @@
+package cd.connect.openapi.support;
+
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+@Provider
+public class OpenApiEnumProvider implements ParamConverterProvider {
+  private final Map<Class<?>, ParamConverter<?>> converterMap = new HashMap<>();
+
+  @Override
+  public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+    final ParamConverter<?> paramConverter = converterMap.get(rawType);
+    if (paramConverter != null) {
+      return (ParamConverter<T>) paramConverter;
+    }
+
+    if (rawType.isEnum()) {
+      try {
+        final Method fromValue = rawType.getMethod("fromValue", String.class);
+
+        final ParamConverter<T> enumConverter = new ParamConverter<T>() {
+          @Override
+          public T fromString(String value) {
+            try {
+              return (T) fromValue.invoke(null, value);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+              return null;
+            }
+          }
+
+          @Override
+          public String toString(T value) {
+            return value.toString();
+          }
+        };
+
+        converterMap.put(rawType, enumConverter);
+
+        return enumConverter;
+      } catch (NoSuchMethodException e) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+}

--- a/maven-plugins/openapi-jersey2-plugin/README.adoc
+++ b/maven-plugins/openapi-jersey2-plugin/README.adoc
@@ -6,7 +6,7 @@ Converts swagger/openapi yaml or json files into JAX-RS apis based on Jersey2
 
 The current authors of this repository are:
 
-- _Irina Southwell (nee Капрельянц Ирина)_, Principal Engineer (https://www.linkedin.com/in/irina-southwell-9727a422/)
+- _Irina Southwell (nee Капрельянц Ирина)_, Senior Software Engineer (https://www.linkedin.com/in/irina-southwell-9727a422/)
 - _Richard Vowles_, Software Developer (https://www.linkedin.com/in/richard-vowles-72035193/)
 
 

--- a/maven-plugins/openapi-jersey3-plugin/README.adoc
+++ b/maven-plugins/openapi-jersey3-plugin/README.adoc
@@ -1,18 +1,18 @@
-= connect-openapi-jersey2
+= connect-openapi-jersey3
 
-Converts swagger/openapi yaml or json files into JAX-RS apis based on Jersey2
+Converts openapi yaml or json files into JAX-RS apis based on Jersey2
 
 == authors
 
 The current authors of this repository are:
 
-- _Irina Southwell (nee Капрельянц Ирина)_, Principal Engineer (https://www.linkedin.com/in/irina-southwell-9727a422/)
+- _Irina Southwell (nee Капрельянц Ирина)_, Senior Software Engineer (https://www.linkedin.com/in/irina-southwell-9727a422/)
 - _Richard Vowles_, Software Developer (https://www.linkedin.com/in/richard-vowles-72035193/)
-
-
 
 == changes
 
+* 7.6: Delegators annotated with @Singleton and support for enums that match the OpenAPI doc exactly, previously
+they had to be upper case or they would not match.
 * 7.5: allowing overrides of individual properties by using x-basename
 * 7.4: fixing headers for etags and allowing non-200 responses
 * 7.1: move to Jakarta APIs

--- a/maven-plugins/openapi-jersey3-plugin/src/it/serverdelegate/oas.yaml
+++ b/maven-plugins/openapi-jersey3-plugin/src/it/serverdelegate/oas.yaml
@@ -334,13 +334,13 @@ components:
     EventStatus:
       type: string
       enum:
-        - STREAMING
-        - ALLOCATING
-        - ALLOCATED
-        - CLOSING
-        - CLOSED
-        - PENDING
-        - ARCHIVING
+        - streaming
+        - Allocating
+        - aLLocaTed
+        - closing
+        - closed
+        - pendinG
+        - archiving
     "com.bluetrainsoftware.AddProps1":
       properties:
         extra:

--- a/maven-plugins/openapi-jersey3-plugin/src/main/resources/jersey3-v3template/DelegateServerService.mustache
+++ b/maven-plugins/openapi-jersey3-plugin/src/main/resources/jersey3-v3template/DelegateServerService.mustache
@@ -15,6 +15,7 @@ import org.glassfish.jersey.media.multipart.FormDataParam;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 {{#imports}}import {{import}};
 {{/imports}}
@@ -28,6 +29,7 @@ import jakarta.inject.Inject;
 
 {{>generatedAnnotation}}
 {{#operations}}
+	@Singleton
   public class {{classname}}Delegator implements {{classname}} {
     private final {{classname}}Delegate delegate;
 

--- a/maven-plugins/openapi-jersey3-plugin/src/main/resources/jersey3-v3template/Service.mustache
+++ b/maven-plugins/openapi-jersey3-plugin/src/main/resources/jersey3-v3template/Service.mustache
@@ -35,13 +35,9 @@ import jakarta.validation.constraints.*;
 {{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}
 {{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}
 {{#operations}}
+
 @Path("{{commonPath}}")
 public interface {{classname}} {
-
-
-  {{#serviceDefaultUrl}}
-      public static String DEFAULT_SERVICE_URL = "{{{serviceDefaultUrl}}}";
-  {{/serviceDefaultUrl}}
 
   {{#operation}}
   /**

--- a/maven-plugins/openapi-jersey3-plugin/src/main/resources/jersey3-v3template/modelEnum.mustache
+++ b/maven-plugins/openapi-jersey3-plugin/src/main/resources/jersey3-v3template/modelEnum.mustache
@@ -1,21 +1,12 @@
-{{#jackson}}
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-{{/jackson}}
-{{#gson}}
-import java.io.IOException;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-{{/gson}}
+
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
  */
-{{#gson}}
-@JsonAdapter({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)
-{{/gson}}
 public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
   {{#allowableValues}}{{#enumVars}}
   {{#enumDescription}}
@@ -32,9 +23,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     this.value = value;
   }
 
-{{#jackson}}
   @JsonValue
-{{/jackson}}
   public {{{dataType}}} getValue() {
     return value;
   }
@@ -48,30 +37,22 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     return this;
   }
 
-{{#jackson}}
+  // can't use map.of
+	private static Map<String,{{{classname}}}> fromValues = new HashMap<>();
+
+  static {
+    {{#allowableValues}}{{#enumVars}}fromValues.put({{{value}}}, {{{name}}});
+    fromValues.put("{{{name}}}", {{{name}}});{{/enumVars}}{{/allowableValues}}
+  }
+
   @JsonCreator
-{{/jackson}}
   public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
-    for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
-      if (String.valueOf(b.value).equals(text)) {
-        return b;
-      }
-    }
-    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
+    {{#useNullForUnknownEnumValue}}
+	  return fromValues.get(text);
+    {{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}
+	{{{classname}}} val = fromValues.get(text);
+	  if (val != null) { return val; }
+    {{/useNullForUnknownEnumValue}}
+	  throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
-{{#gson}}
-
-  public static class Adapter extends TypeAdapter<{{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}> {
-    @Override
-    public void write(final JsonWriter jsonWriter, final {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
-    }
-
-    @Override
-    public {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} read(final JsonReader jsonReader) throws IOException {
-      {{{dataType}}} value = jsonReader.{{#isInteger}}nextInt(){{/isInteger}}{{^isInteger}}next{{{dataType}}}(){{/isInteger}};
-      return {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.fromValue(String.valueOf(value));
-    }
-  }
-{{/gson}}
 }


### PR DESCRIPTION
This ensures that the OffsetDateTime can be supported in query parameters and
adds support for Singleton Delegate Jersey Resources and exact match OpenAPI enums
instead of forcing them to be required to be upper case.